### PR TITLE
DFExport: Handles the dfconvert request and sends the ipykernel notebook format as response

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/dfconvert.svg)](https://badge.fury.io/py/dfconvert)
 [![Build Status](https://travis-ci.org/dataflownb/dfconvert.svg?branch=beta-update)](https://travis-ci.org/dataflownb/dfconvert)
 
-This is a library provided in the form of a bundler extension that allows the conversion of Dataflow notebooks into their IPykernel equivalents. There is no guarantee made that the Notebook that enters will be as efficient as the notebook in the Dfkernel but it will perform in the same way.
+This library allows the conversion of Dataflow notebooks into their IPykernel equivalents. There is no guarantee made that the Notebook that enters will be as efficient as the notebook in the Dfkernel but it will perform in the same way.
 
 A topological sort if also applied to the Notebook to ensure that it can be ran top down.
 
@@ -13,19 +13,24 @@ It relies on IPython core methods for some of the translation process so some ma
 
 1. cd to outer `dfconvert` that contains `setup.py`.
 2. `pip install .`
-3. `jupyter bundlerextension enable --sys-prefix --py dfconvert`
 
 
 ### Usage
-By enabling the bundler extension you will have the option inside of the File -> Download As method which provides two functions Ipykernel Compatible Notebook.
+To export a DataFlow notebook as an IPython kernel notebook using JupyterLab:
+
+1. Open your DataFlow notebook in Jupyter Lab.
+2. Click on the "File" menu located in the top navigation bar.
+3. Navigate to "Save and Export Notebook As".
+4. From the options presented, select "Ipykernel notebook".
 
 Optionally the package can also be called by the use of
 ```
-import dfconvert.make_ipy as ipy
+import nbformat
+from dfnbutils.dfconvert.export import convert_dfnotebook
 file_name = 'mynotebook.ipynb'
 nb = nbformat.read(file_name,nbformat.NO_CONVERT)
-new_file_name = 'mynewnotebook.ipynb'
-dfpy.export_dfpynb(nb, in_fname=file_name, out_fname=new_file_name, md_above=True,full_transform=False,out_mode=False)
+new_file_name = 'mynotebook_ipy.ipynb'
+convert_dfnotebook(nb, in_fname=file_name, out_fname=new_file_name, md_above=False, full_transform=False, out_mode=False)
 ```
 
-This will create a notebook with `out_fname` as an ipykernel compatible notebook if `out_fname` is not set then a file will be created with `file_name` that includes a `_dfpy` before the extension to ensure that files do not become overwritten. `md_above` is a flag for marking markdown cells at the top of the notebook and sending the `full_transform` flag set to true will also convert all `Out[aaaaaa]` style references including those that are inside of comments and inside of strings, by default this set to off. `out_mode` is an additional flag that will make sure that if a cell has any output that is normally created in the dfkernel that this output will be shown in a new cell in the `ipykernel`, this will be repeated for all results found in a tuple. 
+This will create a notebook with `out_fname` as an ipykernel compatible notebook if `out_fname` is not set then a file will be created with `file_name` that includes a `_ipy` before the extension to ensure that files do not become overwritten. `md_above` is a flag for marking markdown cells at the top of the notebook and sending the `full_transform` flag set to true will also convert all `Out[aaaaaa]` style references including those that are inside of comments and inside of strings, by default this set to off. `out_mode` is an additional flag that will make sure that if a cell has any output that is normally created in the dfkernel that this output will be shown in a new cell in the `ipykernel`, this will be repeated for all results found in a tuple. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dfconvert
+# dfnbutils
 
 [![PyPI version](https://badge.fury.io/py/dfconvert.svg)](https://badge.fury.io/py/dfconvert)
 [![Build Status](https://travis-ci.org/dataflownb/dfconvert.svg?branch=beta-update)](https://travis-ci.org/dataflownb/dfconvert)
@@ -11,7 +11,7 @@ It relies on IPython core methods for some of the translation process so some ma
 
 ## Installation Instructions
 
-1. cd to outer `dfconvert` that contains `setup.py`.
+1. cd to outer `dfnbutils` that contains `setup.py`.
 2. `pip install .`
 
 

--- a/dfnbutils/__init__.py
+++ b/dfnbutils/__init__.py
@@ -1,1 +1,2 @@
 from .refs import DataflowRef, identifier_replacer, ref_replacer, dollar_replacer, update_refs, run_replacer, ground_refs, convert_dollar, convert_identifier, get_references
+from .dfconvert.convert import convert_notebook

--- a/dfnbutils/dfconvert/convert.py
+++ b/dfnbutils/dfconvert/convert.py
@@ -1,0 +1,197 @@
+import ast
+import astor
+import asttokens
+import re
+import uuid as uuidlib
+from collections import OrderedDict
+from IPython.core.inputtransformer2 import TransformerManager
+from . import make_ipy
+from .topological import topological
+from .display_cell import display_variable_cell
+from .constants import DEFAULT_ID_LENGTH, DF_CELL_PREFIX
+
+def _transform_outrefs(source_code):
+    # Changes Out[aaa] and Out["aaa"] to Out_aaa
+    pattern = r'Out\[["|\']?([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + r'})["|\']?\]'
+    return re.sub(pattern, r'Out_\1', source_code)
+
+def _replace_export_id(input_string):
+    pattern = r'\[([a-zA-Z0-9]+)\]\[(\d+)\]'
+    return re.sub(pattern, r'Out_\1[\2]', input_string)
+
+def convert_notebook(notebook, md_above=False, full_transform=False, out_mode=False):
+    cell_template = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": []
+    }
+
+    try:
+        code_cells_ref = dict()
+        non_code_cells_ref = OrderedDict()
+        downlinks = dict()
+        nb_output_tags = dict()
+        non_code_cells_block = dict()
+        non_code_cells_seq = dict()
+        transformer_manager = TransformerManager()
+        latest_non_code_cell = None
+
+        # Separate code and non-code cells
+        for cell in notebook['cells']:
+            output_tags = []
+            cell_id = cell['id'].split('-')[0]
+
+            if cell['cell_type'] != "code":
+                non_code_cells_seq[cell_id] = []
+                if latest_non_code_cell and not non_code_cells_block[latest_non_code_cell]:
+                    del non_code_cells_block[latest_non_code_cell]
+                    non_code_cells_seq[cell_id] += non_code_cells_seq[latest_non_code_cell] + [non_code_cells_ref[latest_non_code_cell]]
+                    del non_code_cells_seq[latest_non_code_cell]
+
+                latest_non_code_cell = cell_id
+                non_code_cells_ref[cell_id] = cell
+                non_code_cells_block[cell_id] = set()
+
+            else:
+                if latest_non_code_cell and cell['source']:
+                    non_code_cells_block[latest_non_code_cell].add(cell_id)
+
+                for output in cell.get('outputs', []):
+                    if output.get('metadata') and output['metadata'].get('output_tag'):
+                        output_tags.append(output['metadata']['output_tag'])
+
+                    if 'execution_count' in output and output.get('output_type') in ['stream', 'display_data', 'error', 'update_display_data', 'clear_output']:
+                        del output['execution_count']
+
+                nb_output_tags[cell_id] = output_tags
+                code_cells_ref[cell_id] = [cell]
+
+        # Process each code cell
+        for uuid, cells in code_cells_ref.items():
+            cell = cells[0]
+            make_ipy.ref_uuids = set()
+
+            # Apply transformers
+            persistent_code = cell['metadata']['dfmetadata']['persistentCode']    
+            code = transformer_manager.transform_cell(persistent_code)
+            code = make_ipy.convert_dollar(code, {}, '', replace_f=make_ipy.identifier_replacer)
+            code = make_ipy.convert_identifier(code, make_ipy.underscore_replacer, {})
+            code = make_ipy.convert_output_tags(code, nb_output_tags.get(uuid, []), uuid, code_cells_ref.keys())
+
+            cast = asttokens.ASTTokens(code, parse=True)
+            code = make_ipy.transform_out_refs(code, cast)
+
+            if full_transform:
+                code = _transform_outrefs(code)
+
+            cast = asttokens.ASTTokens(code, parse=True)
+            code = make_ipy.transform_last_node(code, cast, uuid)
+
+            # Handle output assignments
+            valid_tags = [output['metadata']['output_tag'] for output in cell.get('outputs', []) if 'metadata' in output and 'output_tag' in output['metadata']]
+            cast = asttokens.ASTTokens(code, parse=True)
+            code, out_targets = make_ipy.out_assign(code, cast, uuid, valid_tags)
+
+            code_cells_ref[uuid][0]['source'] = code.strip()
+
+            if out_mode:
+                tree = ast.parse(cell['source'])
+                if out_targets:
+                    if isinstance(out_targets, ast.Tuple):
+                        for elt in out_targets.elts:
+                            new_cell = dict(cell_template)
+                            new_cell['source'] = DF_CELL_PREFIX + str(astor.to_source(elt)).rstrip()
+                            code_cells_ref[uuid].append(new_cell)
+
+                if tree.body and isinstance(tree.body[-1], ast.Assign) and isinstance(tree.body[-1].targets, list):
+                    for count, target in enumerate(tree.body[-1].targets):
+                        if (len(tree.body[-1].targets) == count + 1) and isinstance(target, ast.Name) and len(code_cells_ref[uuid]) == 1:
+                            new_cell = dict(cell_template)
+                            new_cell['source'] = DF_CELL_PREFIX + target.id
+                            code_cells_ref[uuid].append(new_cell)
+                        if isinstance(target, ast.Tuple):
+                            for elt in target.elts:
+                                if isinstance(elt, ast.Name):
+                                    new_cell = dict(cell_template)
+                                    new_cell['source'] = DF_CELL_PREFIX + elt.id
+                                    code_cells_ref[uuid].append(new_cell)
+
+            else:
+                # Wrap exported variables into display_variables
+                exported_variables = ""
+
+                if nb_output_tags.get(uuid):
+                    variable_items = []
+                
+                    for val in nb_output_tags[uuid]:
+                        is_uuid_in_val = uuid in val
+                        is_external_ref = len(val) < 8 or val[:8] not in code_cells_ref.keys() or uuid != val[:8]
+                
+                        if is_external_ref:
+                            if is_uuid_in_val:
+                                tag = _replace_export_id(val)
+                                variable_items.append(f'"{tag}": {tag}')
+                            else:
+                                variable_items.append(f'"{val}_{uuid}": {val}_{uuid}')
+                
+                    if variable_items:
+                        exported_variables = "{ " + ", ".join(variable_items) + " }"
+
+
+                if len(exported_variables) > 3:
+                    code += f'\ndisplay_variables({exported_variables})'
+                elif f'Out_{uuid}' in code:
+                    code += f'\ndisplay_variables({{"Out_{uuid}": Out_{uuid}}})'
+
+                code_cells_ref[uuid][0]['source'] = code
+
+            downlinks[uuid] = list(make_ipy.ref_uuids)
+
+        # Topologically sort cells based on dependencies
+        sorted_order = list(topological(downlinks))
+        ordered_cells = []
+
+        if md_above:
+            ordered_cells.extend(non_code_cells_ref.values())
+
+        for cell_id in reversed(sorted_order):
+            if not md_above:
+                for id_, code_ids in non_code_cells_block.items():
+                    if cell_id in code_ids:
+                        if non_code_cells_seq.get(id_):
+                            ordered_cells.extend(non_code_cells_seq[id_])
+                        ordered_cells.append(non_code_cells_ref[id_])
+                        del non_code_cells_block[id_]
+                        break
+            ordered_cells.extend(code_cells_ref[cell_id])
+
+        if not md_above:
+            ordered_cells.extend(non_code_cells_ref[id_] for id_ in non_code_cells_block.keys())
+
+        notebook['cells'] = ordered_cells if out_mode else display_variable_cell + ordered_cells
+
+        # Standardize kernel metadata
+        if 'metadata' in notebook and 'kernelspec' in notebook['metadata']:
+            notebook['metadata']['kernelspec']['display_name'] = "Python 3 (ipykernel)"
+            notebook['metadata']['kernelspec']['name'] = "python3"
+            del notebook['metadata']['dfnotebook']
+            del notebook['metadata']['enable_tags']
+        
+        #clearing the existing metadata and execution count from code cells.
+        final_cells = []
+        for cell in notebook['cells']:
+            cell['id'] = str(uuidlib.uuid4()) # assign new cell ids
+            if cell['cell_type'] == "code":
+                cell['metadata'] = {}
+                cell['execution_count'] = None
+                final_cells.append(cell)
+            else:
+                final_cells.append(cell)
+        
+        notebook['cells'] = final_cells
+        return notebook
+
+    except Exception as e:
+        return ''

--- a/dfnbutils/dfconvert/display_cell.py
+++ b/dfnbutils/dfconvert/display_cell.py
@@ -1,0 +1,19 @@
+display_variable_cell = display_variable_cell = [{ "cell_type": "code", "id": "1" , "execution_count": None, "metadata": {}, "outputs": [], "source":'''from IPython.display import display, HTML
+import html
+def display_variables(variables):
+    """
+    Used for printing variables(Referred in DFPython 3 notebook)
+    Args:
+    - variables (dict): A dictionary containing variable names as keys and their corresponding values.
+    """
+    html_template = """
+    <style>.jp-RenderedHTMLCommon tbody tr:nth-child(even) {{ background: none; }}</style>
+    <div style='opacity:80%;font-size:12px;padding-left: 6px'><br>DFPython 3 referred variables</div>
+    <table>{}</table>"""
+    
+    row_template = "<tr><td style='color: #bf5b3d;text-align:left;vertical-align:top;'>{}</td><td style='text-align:left'> {}</td></tr>"
+    rows = [row_template.format(name+':', value._repr_html_()) if hasattr(value, '_repr_html_') else row_template.format(name+':', html.escape(str(value))) for name, value in variables.items()]
+    output_html = html_template.format("\\n".join(rows))
+    output_html = f"<div style='pointer-events: none;'>{output_html}</div>"
+    display(HTML(output_html))'''
+}]

--- a/dfnbutils/dfconvert/export.py
+++ b/dfnbutils/dfconvert/export.py
@@ -1,0 +1,15 @@
+import json
+import os
+from .convert import convert_notebook
+
+def convert_dfnotebook(notebook, in_fname, out_fname = None, md_above=False, full_transform=False, out_mode=False):
+    if out_fname == None or len(out_fname.strip()) == 0:
+        base_name = os.path.splitext(os.path.basename(in_fname))[0]
+        out_fname_file = base_name + '_ipy' + '.ipynb'
+        out_fname = os.path.join(os.path.dirname(in_fname), out_fname_file)
+    nb = convert_notebook(notebook, md_above=md_above, full_transform=full_transform, out_mode=out_mode)
+    if len(nb) == 0:
+        print("Error occured, please check the notebook and try again.")
+    else:
+        with open(out_fname, 'w') as json_file:
+            json.dump(nb, json_file)

--- a/dfnbutils/dfconvert/make_ipy.py
+++ b/dfnbutils/dfconvert/make_ipy.py
@@ -1,28 +1,128 @@
-from collections import defaultdict
-import json
-import os
-from dfconvert.constants import DEFAULT_ID_LENGTH,DF_CELL_PREFIX
-from dfconvert.topological import topological
 import ast
-#Adds tokens to the ast
+import ast_comments
+from io import StringIO
+from .constants import DEFAULT_ID_LENGTH
+from ..refs import (
+    DataflowRef, identifier_replacer, ref_replacer,
+    run_replacer, convert_dollar, convert_identifier,
+    DataflowLinker as RefLinker, underscore_replacer
+)
+import tokenize
+import json
+from typing import Any
+import itertools
 import asttokens
-import IPython.core
-import re
 import astor
-import sys
+import builtins
+import re
 
 
-cell_template = {
-   "cell_type": "code",
-   "execution_count": None,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
+ref_uuids = set()
 
+def convert_output_tags(code, output_tags, uuid, uuids_in_nb):
+    def update_identifier(identifier, scope, imported_library = False):
+        #case for imported library
+        if imported_library:
+            return identifier + f' as {identifier}_{uuid}'
+        
+        #check local scopes
+        if len(scope) > 1:
+            #checking local scopes
+            for scope_vars in scope[:0:-1]:
+                if identifier in scope_vars:
+                    return identifier
+                
+        #check if identifier already converted      
+        for id in uuids_in_nb:
+            if id in identifier:
+                ref_uuids.add(id)
+                return identifier
+            
+        #special case: not available in 3.12.2 but available in 3.10
+        if identifier == 'get_ipython':
+            return identifier
+        
+        return identifier if identifier in dir(builtins) else f"{identifier}_{uuid}"
+    
+    class DFconvertDataflowLinker(RefLinker):
+        def visit_Name(self, node):
+            if isinstance(node.ctx, ast.Store):
+                self.scope[-1].add(node.id)
+                node.id = update_identifier(node.id, self.scope)
+            elif isinstance(node.ctx, ast.Del):
+                self.scope[-1].discard(node.id)
+            elif isinstance(node.ctx, ast.Load):
+                if node.id != 'Out':
+                    node.id = update_identifier(node.id, self.scope)
+            self.generic_visit(node)
 
-transformers = []
+        def visit_Subscript(self, node):
+            if isinstance(node.value, ast.Name) and node.value.id == 'Out':
+                if isinstance(node.slice, ast.Index) and isinstance(node.slice.value, ast.Str):
+                    subscript_value = node.slice.value.s
+                    new_id = f'Out_{subscript_value}'
+                    if len(new_id) > 7 and new_id[:8] in uuids_in_nb:
+                        ref_uuids.add(new_id[:8])
+                        node.value = ast.Name(id=new_id, ctx=ast.Load())
+            self.generic_visit(node)
 
+        def process_import(self, node):
+            for index, alias in enumerate(node.names):
+                if alias.asname:
+                    self.scope[-1].add(alias.asname)
+                    node.names[index].asname = update_identifier(alias.asname, self.scope)
+                else:
+                    self.scope[-1].add(alias.name)
+                    node.names[index].name = update_identifier(alias.name, self.scope, True)
+            self.generic_visit(node)
+        
+        def process_function(self, node, add_name=True):
+            if add_name:
+                self.scope[-1].add(node.name)
+                node.name = update_identifier(node.name, self.scope)
+            func_args = set()
+            for a in itertools.chain(node.args.args, node.args.posonlyargs, node.args.kwonlyargs):
+                func_args.add(a.arg)
+            self.scope.append(func_args)
+            retval = self.generic_visit(node)
+            self.scope.pop()
+            return retval
+
+        def visit_ClassDef(self, node):
+            self.scope[-1].add(node.name)
+            node.name = update_identifier(node.name, self.scope)
+            self.scope.append(set())
+            retval = self.generic_visit(node)
+            self.scope.pop()
+            return retval
+
+        def visit_ExceptHandler(self, node):
+            self.scope.append(set())
+            if node.name:
+                self.scope[-1].add(node.name)
+                node.name = update_identifier(node.name, self.scope)
+            retval = self.generic_visit(node)
+            self.scope.pop()
+            return retval
+
+    tree = ast_comments.parse(code)
+    linker = DFconvertDataflowLinker(dataflow_state=None, execution_count=None, output_tags={}, cell_refs={}, reversion=False, display_code=False)
+    
+    linker.visit(tree)
+    return ast_comments.unparse(tree)
+
+def transform_out_refs(csource,cast):
+    offset = 0
+    #Depth first traversal otherwise offset won't be accurate
+    for node in asttokens.util.walk(cast.tree):
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name) and node.value.id == 'Out':
+            start, end = node.first_token.startpos + offset, node.last_token.endpos + offset
+            #new_id = re.sub('Out\[[\"|\']?([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + '})[\"|\']?\]', r'Out_\1', csource[start:end])
+            new_id = re.sub(r'Out\[(?:["\']?)?([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + r'})(?:["\']?)?\]', r'Out_\1', csource[start:end])
+            csource = csource[:start] + new_id + csource[end:]
+            ref_uuids.add(new_id[4:])
+            offset = offset + (len(new_id) - (end - start))
+    return csource
 
 def transform_last_node(csource,cast,exec_count):
     if isinstance(exec_count,int):
@@ -42,7 +142,8 @@ def transform_last_node(csource,cast,exec_count):
                     tuple_eles.append(ast.Name('Out_' + str(exec_count) + '['+str(idx)+']', ast.Store))
             if (named_flag):
                 nnode = ast.Assign([ast.Tuple(tuple_eles, ast.Store)], expr_val)
-                out_assign = 'Out_'+str(exec_count)+' = []\n' if out_exists else ''
+                tuple_content = astor.to_source(expr_val).strip()[1:-1]
+                out_assign = f'Out_{exec_count} = [{tuple_content}]\n' if out_exists else ''
                 ast.fix_missing_locations(nnode)
                 start,end = cast.tree.body[-1].first_token.startpos, cast.tree.body[-1].last_token.endpos
                 csource = csource[:start] + out_assign + astor.to_source(nnode) + csource[end:]
@@ -51,6 +152,10 @@ def transform_last_node(csource,cast,exec_count):
 def out_assign(csource,cast,exec_count,tags):
     #This is a special case where an a,3 type assignment happens
     tag_flag = bool([True if exec_count in (tag[:DEFAULT_ID_LENGTH] for tag in tags) else False].count(True))
+
+    if len(cast.tree.body) > 0 and isinstance(cast.tree.body[-1], ast.Expr) and isinstance(cast.tree.body[-1].value, ast.Call):
+        return csource, []
+
     if tag_flag:
         if isinstance(cast.tree.body[-1], ast.Assign):
             new_node = ast.Name('Out_' + str(exec_count), ast.Store)
@@ -60,7 +165,7 @@ def out_assign(csource,cast,exec_count,tags):
             ast.fix_missing_locations(nnode)
             start, end = cast.tree.body[-1].first_token.startpos, cast.tree.body[-1].last_token.endpos
             csource = csource[:start] + astor.to_source(nnode) + csource[end:]
-        return csource, out_targets
+            return csource, out_targets
     if len(cast.tree.body) < 1:
         return csource, []
     if isinstance(cast.tree.body[-1],ast.Expr):
@@ -77,198 +182,3 @@ def out_assign(csource,cast,exec_count,tags):
         start, end = cast.tree.body[-1].first_token.startpos, cast.tree.body[-1].last_token.endpos
         csource = csource[:start] + astor.to_source(nnode) + csource[end:]
     return csource, []
-
-
-def transform_out_refs(csource,cast):
-    offset = 0
-    #Depth first traversal otherwise offset won't be accurate
-    for node in asttokens.util.walk(cast.tree):
-        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name) and node.value.id == 'Out':
-            start, end = node.first_token.startpos + offset, node.last_token.endpos + offset
-            new_id = re.sub('Out\[[\"|\']?([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + '})[\"|\']?\]', r'Out_\1',
-                            csource[start:end])
-            csource = csource[:start] + new_id + csource[end:]
-            offset = offset + (len(new_id) - (end - start))
-    return csource
-
-
-def export_dfpynb(d, in_fname=None, out_fname=None, md_above=True,full_transform=False,out_mode=False):
-    last_code_id = None
-    non_code_map = defaultdict(list)
-    code_cells = {}
-    deps = defaultdict(list)
-    out_tags = defaultdict(list)
-    refs = {}
-
-
-    def grab_deps(cast,exec_count):
-        for node in ast.walk(cast.tree):
-            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-                out_ref = re.search('(?<=Out_)([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + '})', node.id)
-                if out_ref:
-                    deps[exec_count].append(out_ref.group(0))
-                else:
-                    deps[exec_count].append(node.id)
-            # Grab magic lines and perform our own parsing
-            elif isinstance(node, ast.Call) and isinstance(node.func,
-                                                           ast.Attribute) and node.func.attr == 'run_line_magic' and node.args:
-                args = node.args
-                if args[0].s == 'split_out':
-                    for subnode in ast.walk(ast.parse(args[1].s)):
-                        if isinstance(subnode, ast.Name):
-                            deps[exec_count].append(subnode.id)
-
-    #FIXME: Give access to this somewhere
-    #This converts comments and strings as well not just in code identifiers
-    if (full_transform):
-        def transform(line):
-            # Changes Out[aaa] and Out["aaa"] to Out_aaa
-            return re.sub('Out\[[\"|\']?([0-9A-Fa-f]{' + str(DEFAULT_ID_LENGTH) + '})[\"|\']?\]', r'Out_\1', line)
-
-        out_transformer = IPython.core.inputtransformer.StatelessInputTransformer(transform)
-        transformers.append(out_transformer)
-
-    transformer = IPython.core.inputsplitter.IPythonInputSplitter(physical_line_transforms=transformers)
-
-    if md_above:
-        # reverse the cells
-        d["cells"].reverse()
-
-    for count, cell in enumerate(d['cells']):
-        if cell['cell_type'] != "code":
-            # keep non-code cells above or below code cell
-            non_code_map[last_code_id].append(cell)
-        else:
-            # This condition should never happen but incase it does
-            # we want to ignore cells without any execution count
-            if ('execution_count' in cell):
-                exec_count = hex(cell['execution_count'])[2:].zfill(DEFAULT_ID_LENGTH)
-
-                if 'metadata' in cell:
-                    cell.metadata.dfkernel_old_id = cell['execution_count']
-                last_code_id = exec_count
-                csource = cell['source']
-                if not isinstance(csource, str):
-                    csource = "".join(csource)
-                csource = transformer.transform_cell(csource)
-                cast = asttokens.ASTTokens(csource, parse=True)
-
-
-                if not full_transform:
-                    csource = transform_out_refs(csource,cast)
-
-
-                csource = transform_last_node(csource,cast,exec_count)
-
-                #Grab depedencies from cell
-                grab_deps(cast,exec_count)
-
-
-                #Create list of all out_tags
-                valid_tags = []
-                if ('outputs' in cell):
-                    for output in cell['outputs']:
-                        if ('metadata' in output and 'output_tag' in output['metadata']):
-                            valid_tags.append(output['metadata']['output_tag'])
-
-
-
-                cast = asttokens.ASTTokens(csource, parse=True)
-                #Finish up by assigning all final expressions if they still don't have a value
-                csource,out_targets = out_assign(csource,cast,exec_count,valid_tags)
-                cell['source'] = DF_CELL_PREFIX + csource.rstrip()
-
-
-                for out_tag in valid_tags:
-                    out_tags[exec_count].append(out_tag)
-                    refs[out_tag] = exec_count
-                code_cells[exec_count] = [cell]
-                if out_mode:
-                    tree = ast.parse(cell['source'])
-                    if out_targets:
-                        if isinstance(out_targets, ast.Tuple):
-                            for j in out_targets.elts:
-                                new_cell = dict(cell_template)
-                                new_cell['source'] = DF_CELL_PREFIX + str(astor.to_source(j)).rstrip()
-                                code_cells[exec_count].append(new_cell)
-                    if tree.body and isinstance(tree.body[-1], ast.Assign) and isinstance(tree.body[-1].targets, list):
-                        for count, i in enumerate(tree.body[-1].targets):
-                            if len(tree.body[-1].targets) == count+1 and isinstance(i,ast.Name) and len(code_cells[exec_count]) == 1:
-                                new_cell = dict(cell_template)
-                                new_cell['source'] = DF_CELL_PREFIX + str(i.id)
-                                code_cells[exec_count].append(new_cell)
-                            if isinstance(i, ast.Tuple):
-                                for j in i.elts:
-                                    if isinstance(j, ast.Name):
-                                        new_cell = dict(cell_template)
-                                        new_cell['source'] = DF_CELL_PREFIX + str(j.id)
-                                        code_cells[exec_count].append(new_cell)
-                if exec_count not in deps:
-                    deps[exec_count] = []
-            else:
-                continue
-
-    cells = []
-    cells.extend(non_code_map[None])
-
-    # Remove all namenodes that aren't output tags
-    out_tag_set = sorted({x for v in out_tags.values() for x in v})
-    valid_keys = out_tag_set + list(deps)
-
-    for node in deps:
-        #Ensure that keys are valid NameNode refs and then
-        #Ensure that we don't have circular dependencies where a cell depends on itself
-        deps[node] = list(set(deps[node]).intersection(valid_keys).difference(set(out_tags[node])))
-
-    #Convert all tag references into dependency references
-    for tag in deps:
-        for idx, dep in enumerate(deps[tag]):
-            if dep in refs:
-                deps[tag][idx] = refs[dep]
-
-    topo_deps = list(topological(deps))
-
-    while topo_deps:
-        cid = topo_deps.pop()
-        cells.extend(non_code_map[cid])
-        cells.extend(code_cells[cid])
-
-    d['cells'] = cells
-
-    # change the kernelspec
-    # FIXME what if this metadata doesn't exist?
-    d["metadata"]["kernelspec"]["display_name"] = "Python 3"
-    d["metadata"]["kernelspec"]["name"] = "python3"
-
-    if out_fname is None:
-        if in_fname is not None:
-            dir_name, base_name = os.path.split(os.path.abspath(in_fname))
-            base, ext = os.path.splitext(base_name)
-            out_fname = os.path.join(dir_name, base + '_ipy' + ext)
-
-    if out_fname is None:
-        json.dump(d, sys.stdout, indent=4)
-    else:
-        with open(out_fname, 'w') as f:
-            json.dump(d, f, indent=4)
-
-    return out_fname
-
-def bundle(handler, model):
-    """Converts the existing IPython Notebook file into a Dataflow Kernel File"""
-    notebook_filename = model['path']
-    notebook_content = model['content']
-    handler.finish('File Exported As: {}'.format(export_dfpynb(notebook_content, notebook_filename)))
-
-if __name__ == "__main__":
-    import sys
-    if len(sys.argv) < 2:
-        print("Usage: python {} <dfnb filename> [out filename]".format(sys.argv[0]))
-        sys.exit(1)
-
-    out_fname = None
-    if len(sys.argv) > 2:
-        out_fname = sys.argv[2]
-    with open(sys.argv[1], "r") as f:
-        d = json.load(f)
-        export_dfpynb(d, sys.argv[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 "ipython>=7.17.0",
 "astor>=0.7",
 "asttokens>1.1",
+"ast-comments>1.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR includes the following changes:

- **Refactor:** Moved `DataflowLinker` to a shared module to enable reuse in `dfconvert` and related tools.
- **Feature:** Added support for exporting notebooks in "ipykernel notebook" format via the "Save and Export Notebook As" menu.
- **Docs:** Updated the README with instructions and context for the new export option.

